### PR TITLE
Drop protocol argument

### DIFF
--- a/tests/test_smolpickle.py
+++ b/tests/test_smolpickle.py
@@ -13,11 +13,6 @@ import smolpickle
 BATCHSIZE = 1000
 
 
-def test_module_constants():
-    assert smolpickle.HIGHEST_PROTOCOL == 5
-    assert smolpickle.DEFAULT_PROTOCOL == 5
-
-
 def test_picklebuffer_is_shared():
     assert pickle.PickleBuffer is smolpickle.PickleBuffer
 
@@ -30,14 +25,6 @@ def test_exceptions_are_unique():
 
 def test_module_version():
     StrictVersion(smolpickle.__version__)
-
-
-def test_pickler_init_errors():
-    with pytest.raises(ValueError, match="pickle protocol must be <="):
-        smolpickle.Pickler(protocol=6)
-
-    with pytest.raises(ValueError, match="pickle protocol must be >="):
-        smolpickle.Pickler(protocol=4)
 
 
 def check(obj, sol=None):


### PR DESCRIPTION
Smolpickle now contains a few custom opcodes, so I'm leaning towards
considering smolpickle a "pickle-like serializer" rather than a simpler
pickle (I might even rename the library). As such we can drop
unnecessary arguments like protocol, since the protocol here has less
meaning. This saves us 2 bytes per msg (minimal), but reduces the api
surface which I like.