### PR TITLE
Rename to quickle

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include smolpickle.c
+include quickle.c
 include setup.py
 include README.rst
 include LICENSE

--- a/setup.py
+++ b/setup.py
@@ -3,19 +3,19 @@ import os
 from setuptools import setup, find_packages
 from setuptools.extension import Extension
 
-ext_modules = [Extension("smolpickle", ["smolpickle.c"])]
+ext_modules = [Extension("quickle", ["quickle.c"])]
 
 setup(
-    name="smolpickle",
+    name="quickle",
     version="0.0.2",
     maintainer="Jim Crist-Harif",
     maintainer_email="jcristharif@gmail.com",
-    url="https://github.com/jcrist/smolpickle",
+    url="https://github.com/jcrist/quickle",
     project_urls={
-        "Source": "https://github.com/jcrist/smolpickle/",
-        "Issue Tracker": "https://github.com/jcrist/smolpickle/issues",
+        "Source": "https://github.com/jcrist/quickle/",
+        "Issue Tracker": "https://github.com/jcrist/quickle/issues",
     },
-    description="Like pickle, but smol",
+    description="A quicker pickle",
     classifiers=[
         "License :: OSI Approved :: BSD License",
         "Programming Language :: Python :: 3.8",

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -3,7 +3,7 @@ import copy
 
 import pytest
 
-from smolpickle import Struct, PickleBuffer
+from quickle import Struct, PickleBuffer
 
 
 def as_tuple(x):
@@ -14,7 +14,7 @@ def test_struct_class_attributes():
     assert Struct.__struct_fields__ == ()
     assert Struct.__struct_defaults__ == ()
     assert Struct.__slots__ == ()
-    assert Struct.__module__ == "smolpickle"
+    assert Struct.__module__ == "quickle"
 
 
 def test_struct_instance_attributes():


### PR DESCRIPTION
Since we're no longer a subset of pickle (but now have some custom
opcodes as well), the `smol` designation no longer makes sense.

Renames:
- `smolpickle` -> `quickle`
- `Pickler` -> `Encoder`
- `Unpickler` -> `Decoder`
- `PickleError` -> `QuickleError`
- `PicklingError` -> `EncodingError`
- `UnpicklingError` -> `DecodingError`